### PR TITLE
Check the decrypted value to be string before calling `String.length/1`

### DIFF
--- a/lib/ex_aws_s3_crypto.ex
+++ b/lib/ex_aws_s3_crypto.ex
@@ -189,7 +189,7 @@ defmodule ExAws.S3.Crypto do
       byte_size(decrypted) == expected ->
         {:ok}
 
-      String.length(decrypted) == expected ->
+      is_binary(decrypted) and String.length(decrypted) == expected ->
         # due to a bug in the way size was previously calculated (using String.length) don't
         # error if the String length of the decrypted result matches the expected value
         {:ok}


### PR DESCRIPTION
I've encountered a case when the `decrypted` value in `validate_length/2` is not a string and when it calls `String.length/1` on it I'd get an argument error. This PR adds the check to ensure that the value is actually a string.