### PR TITLE
Remove automatic check for expected length, version bump to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v3.1.0 (2023-08-02)
+
+### Removed
+
+  * Removed automatic check to ensure the decrypted object has the same size as the metadata indicates. `valid_length?/1` can now be optionally used for this check.
+
 ## v3.0.2 (2023-08-01)
 
 ### Bug Fixes

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAwsS3Crypto.MixProject do
   use Mix.Project
 
-  @version "3.0.2"
+  @version "3.1.0"
   @repo "https://github.com/bmuller/ex_aws_s3_crypto"
 
   def project do


### PR DESCRIPTION
This PR removes the automatic check to ensure the decrypted object has the same size as the metadata indicates. The function `valid_length?/1` can now be optionally used for this check.